### PR TITLE
Initial tests for InnerMajoritySet and OuterSet

### DIFF
--- a/contracts/validator/.eslintrc
+++ b/contracts/validator/.eslintrc
@@ -11,6 +11,7 @@
   },
   "globals": {
     "assert": false,
+    "assertRevert": false,
     "artifacts": false,
     "contract": false,
     "web3": false

--- a/contracts/validator/contracts/OuterSet.sol
+++ b/contracts/validator/contracts/OuterSet.sol
@@ -39,6 +39,9 @@ contract OuterSet is ValidatorSet {
         OwnershipTransferred(0, owner);
 
         if (innerSetInitial == 0) {
+            // HACK: Hardcode address when in genesis block
+            // Maybe not safe to use this address
+            // Parity minimum address is 5?
             innerSet = InnerSet(0x0000000000000000000000000000000000000006);
         } else {
             innerSet = InnerSet(innerSetInitial);

--- a/contracts/validator/contracts/OuterSet.sol
+++ b/contracts/validator/contracts/OuterSet.sol
@@ -34,6 +34,7 @@ contract OuterSet is ValidatorSet {
         } else { // this is deployed as part of a test
             owner = msg.sender;
             systemAddress = msg.sender;
+            finalized = true; // Parity calls finalization on the contract initially
         }
 
         OwnershipTransferred(0, owner);

--- a/contracts/validator/migrations/2_validators.js
+++ b/contracts/validator/migrations/2_validators.js
@@ -22,7 +22,6 @@ async function deployDevelopment(deployer) {
     .deploy(InnerSetInitial)
     .then(() => deployer.deploy(OuterSet, InnerSetInitial.address))
     .then(() => OuterSet.deployed())
-    .then(outerSet => outerSet.finalizeChange())
     .then(() => deployInnerMajoritySet(deployer, OuterSet.address));
 }
 

--- a/contracts/validator/test/InnerMajoritySet.test.js
+++ b/contracts/validator/test/InnerMajoritySet.test.js
@@ -1,6 +1,5 @@
 const OuterSet = artifacts.require("OuterSet");
 const InnerMajoritySet = artifacts.require("InnerMajoritySet");
-// const { BigNumber } = require("web3");
 
 contract("InnerMajoritySet", () => {
   const initialValidators = [
@@ -34,14 +33,17 @@ contract("InnerMajoritySet", () => {
       assert.equal(validatorSet[0], initialValidators[0]);
       assert.equal(validatorSet[1], initialValidators[1]);
       assert.equal(validatorSet[2], initialValidators[2]);
-      assert.equal(
-        validatorSet[3],
-        "0x0000000000000000000000000000000000000000"
-      );
+
+      for (let i = 3; i < 31; i += 1) {
+        assert.equal(
+          validatorSet[3],
+          "0x0000000000000000000000000000000000000000"
+        );
+      }
     });
   });
 
-  describe("addSupport", () => {
+  describe("getSupport", () => {
     it("gets support for a validator", async () => {
       const set = await InnerMajoritySet.deployed();
       const toAddr = initialValidators[1];

--- a/contracts/validator/test/InnerMajoritySet.test.js
+++ b/contracts/validator/test/InnerMajoritySet.test.js
@@ -2,7 +2,7 @@ const OuterSet = artifacts.require("OuterSet");
 const InnerMajoritySet = artifacts.require("InnerMajoritySet");
 // const { BigNumber } = require("web3");
 
-contract("InnerMajoritySet", accounts => {
+contract("InnerMajoritySet", () => {
   const initialValidators = [
     "0xfc4c1475c4dabfcbb49dc2138337f9db8eedff58",
     "0xa2557ab1f214600a7ad1fa12fcad0c97135eeea6",

--- a/contracts/validator/test/InnerMajoritySet.test.js
+++ b/contracts/validator/test/InnerMajoritySet.test.js
@@ -1,0 +1,52 @@
+const OuterSet = artifacts.require("OuterSet");
+const InnerMajoritySet = artifacts.require("InnerMajoritySet");
+// const { BigNumber } = require("web3");
+
+contract("InnerMajoritySet", accounts => {
+  const initialValidators = [
+    "0xfc4c1475c4dabfcbb49dc2138337f9db8eedff58",
+    "0xa2557ab1f214600a7ad1fa12fcad0c97135eeea6",
+    "0x442290b65483db5f2520b1e8609bd3e47fd3f3c4"
+  ];
+
+  describe("constructor", () => {
+    it("sets the outerSet address", async () => {
+      const outer = await OuterSet.deployed();
+      const set = await InnerMajoritySet.new(outer.address);
+      const outerAddress = await set.outerSet();
+      assert.equal(outer.address, outerAddress);
+    });
+
+    it("sets the outerSet address to 5 if passed in 0", async () => {
+      const set = await InnerMajoritySet.new(0);
+      const outerAddress = await set.outerSet();
+      const expected = "0x0000000000000000000000000000000000000005";
+      assert.equal(expected, outerAddress);
+    });
+  });
+
+  describe("getValidators", () => {
+    it("gets the validators", async () => {
+      const set = await InnerMajoritySet.new(0);
+      const [validatorSet, length] = await set.getValidators();
+
+      assert.equal(length, 3);
+      assert.equal(validatorSet[0], initialValidators[0]);
+      assert.equal(validatorSet[1], initialValidators[1]);
+      assert.equal(validatorSet[2], initialValidators[2]);
+      assert.equal(
+        validatorSet[3],
+        "0x0000000000000000000000000000000000000000"
+      );
+    });
+  });
+
+  describe("addSupport", () => {
+    it("gets support for a validator", async () => {
+      const set = await InnerMajoritySet.deployed();
+      const toAddr = initialValidators[1];
+      const initialSupport = await set.getSupport(toAddr);
+      assert.equal(initialSupport.toString(), "3");
+    });
+  });
+});

--- a/contracts/validator/test/OuterSet.test.js
+++ b/contracts/validator/test/OuterSet.test.js
@@ -1,3 +1,5 @@
+const assertRevert = require("./helpers/assertRevert").default;
+
 const OuterSet = artifacts.require("OuterSet");
 
 contract("OuterSet", accounts => {
@@ -36,6 +38,25 @@ contract("OuterSet", accounts => {
         assert.equal(logs[0].args.newOwner, accounts[0]);
         done();
       });
+    });
+  });
+
+  describe("transferOwnership", () => {
+    it("can transfer ownership", async () => {
+      const newOwner = "0x0000000000000000000000000000000000001337";
+      const currentOwner = await set.owner.call();
+      await set.transferOwnership.sendTransaction(newOwner, {
+        from: currentOwner
+      });
+      const actual = await set.owner.call();
+      assert.equal(actual, newOwner);
+    });
+
+    it("should prevent transferOwnership from non-owners", async () => {
+      const notOwner = accounts[2];
+      const owner = await set.owner();
+      assert.notEqual(notOwner, owner);
+      await assertRevert(set.transferOwnership(notOwner, { from: notOwner }));
     });
   });
 });

--- a/contracts/validator/test/OuterSet.test.js
+++ b/contracts/validator/test/OuterSet.test.js
@@ -7,8 +7,35 @@ contract("OuterSet", accounts => {
     set = await OuterSet.new();
   });
 
-  it("should set the owner", async () => {
-    const owner = await set.owner.call();
-    assert.equal(owner, accounts[0]);
+  describe("constructor", () => {
+    it("sets the owner", async () => {
+      const owner = await set.owner.call();
+      assert.equal(owner, accounts[0]);
+    });
+
+    it("has a default initial InnerSet in the genesis block", async () => {
+      const expected = "0x0000000000000000000000000000000000000006";
+      const actual = await set.innerSet.call();
+      assert.equal(actual, expected);
+    });
+
+    it("sets the innerSet when passed in as a parameter", async () => {
+      const expected = "0x0000000000000000000000000000000000001337";
+      const testOuterSet = await OuterSet.new(expected);
+      const actual = await testOuterSet.innerSet.call();
+      assert.equal(actual, expected);
+    });
+
+    it("emits an OwnershipTransferred event", done => {
+      const eventsFilter = set.allEvents({ fromBlock: 0, toBlock: "latest" });
+      eventsFilter.get((err, logs) => {
+        const expectedPreviousOwner =
+          "0x0000000000000000000000000000000000000000";
+        assert.equal(logs.length, 1);
+        assert.equal(logs[0].args.previousOwner, expectedPreviousOwner);
+        assert.equal(logs[0].args.newOwner, accounts[0]);
+        done();
+      });
+    });
   });
 });

--- a/contracts/validator/test/helpers/assertRevert.js
+++ b/contracts/validator/test/helpers/assertRevert.js
@@ -1,0 +1,32 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2016 Smart Contract Solutions, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+exports.default = async promise => {
+  try {
+    await promise;
+    assert.fail("Expected revert not received");
+  } catch (error) {
+    const revertFound = error.message.search("revert") >= 0;
+    assert(revertFound, `Expected "revert", got ${error} instead`);
+  }
+};

--- a/contracts/validator/test/helpers/expectThrow.js
+++ b/contracts/validator/test/helpers/expectThrow.js
@@ -1,0 +1,44 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2016 Smart Contract Solutions, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+exports.default = async promise => {
+  try {
+    await promise;
+  } catch (error) {
+    // TODO: Check jump destination to destinguish between a throw
+    //       and an actual invalid jump.
+    const invalidOpcode = error.message.search("invalid opcode") >= 0;
+    // TODO: When we contract A calls contract B, and B throws, instead
+    //       of an 'invalid jump', we get an 'out of gas' error. How do
+    //       we distinguish this from an actual out of gas event? (The
+    //       testrpc log actually show an 'invalid jump' event.)
+    const outOfGas = error.message.search("out of gas") >= 0;
+    const revert = error.message.search("revert") >= 0;
+    assert(
+      invalidOpcode || outOfGas || revert,
+      `Expected throw, got '${error}' instead`
+    );
+    return;
+  }
+  assert.fail("Expected throw not received");
+};


### PR DESCRIPTION
Just some initial tests. Some functions are impossible to test?

For example, `InnerMajoritySet.initiateChange` can only be called from the inner set, but there doesn't seem to be a way to call a function from a contract address.