### PR TITLE
Fix initial inner set size being hardcoded to 3

### DIFF
--- a/contracts/validator/contracts/OuterSet.sol
+++ b/contracts/validator/contracts/OuterSet.sol
@@ -166,11 +166,12 @@ contract InnerSetInitial is InnerSet {
     // Initial set of validator list
     address[32] public validatorsList;
     // Number of initial validator list
-    uint numberOfValidators = 3;
+    uint numberOfValidators;
 
-    function InnerSetInitial(address outerSetAddress, address[32] initialValidators) public {
+    function InnerSetInitial(address outerSetAddress, address[32] initialValidators, uint initialValidatorsSize) public {
         outerSet = OuterSet(0x0000000000000000000000000000000000000005);
         validatorsList = initialValidators;
+        numberOfValidators = initialValidatorsSize;
     }
 
     function getValidators() public constant returns (address[32], uint) {

--- a/contracts/validator/migrations/2_validators.js
+++ b/contracts/validator/migrations/2_validators.js
@@ -29,7 +29,12 @@ function deployInnerMajoritySet(deployer, outerSetAddress) {
 // `InnerSetInitial` can be skipped
 async function deployDevelopment(deployer) {
   await deployer
-    .deploy(InnerSetInitial, genesisOuterSetAddress, initialValidators)
+    .deploy(
+      InnerSetInitial,
+      genesisOuterSetAddress,
+      initialValidators,
+      initialValidators.length
+    )
     .then(() =>
       deployer.deploy(OuterSet, InnerSetInitial.address, masterAddress)
     )


### PR DESCRIPTION
A wrong validator set size will cause `OuterSet#setInner` to fail as there is a length check in `setInner`.