### PR TITLE
Add CLI for interacting with set contracts

### DIFF
--- a/contracts/validator/package.json
+++ b/contracts/validator/package.json
@@ -9,6 +9,7 @@
     "lint:sol": "solium -d contracts/",
     "eslint": "eslint . --ext .js --ext .jsx",
     "generate:genesis": "truffle exec scripts/genesis/generate.js",
+    "cli": "truffle exec scripts/cli/index.js",
     "test": "truffle test --network development",
     "test:ci": "truffle test --network docker_ci"
   },

--- a/contracts/validator/scripts/cli/index.js
+++ b/contracts/validator/scripts/cli/index.js
@@ -1,0 +1,71 @@
+const yargs = require("yargs");
+const _ = require("lodash");
+
+const OuterSet = artifacts.require("OuterSet");
+const InnerSetInitial = artifacts.require("InnerSetInitial");
+const InnerMajoritySet = artifacts.require("InnerMajoritySet");
+const InnerSet = artifacts.require("InnerSet");
+
+const clearScreen = () => {
+  console.log("\x1Bc"); // eslint-disable-line
+};
+
+const handleInner = async argv => {
+  if (argv.clear) {
+    clearScreen();
+  }
+
+  const outer = await OuterSet.at(argv.outerset);
+  const inner = await InnerSet.at(await outer.innerSet());
+
+  switch (argv.action) {
+    case "deploy": {
+      const newInner = await InnerMajoritySet.new(
+        outer.address,
+        argv.validators
+      );
+      outer.setInner(newInner.address);
+      console.log(await outer.innerSet()); // eslint-disable-line
+      break;
+    }
+    case "validators": {
+      const [validators, validatorCount] = await inner.getValidators();
+      console.log(validators.slice(0, validatorCount).join("\n")); // eslint-disable-line
+      break;
+    }
+    default:
+      break;
+  }
+};
+
+module.exports = async function cli(cb) {
+  try {
+    yargs
+      .option("clear", {
+        description: "clear the screen before printing output",
+        default: false,
+        type: "boolean"
+      })
+      .command({
+        command: "inner <action>",
+        description: "interact with inner validator contracts",
+        builder: _yargs => {
+          _yargs
+            .choices("action", ["deploy", "validators"])
+            .option("outerset", { string: true, default: OuterSet.address })
+            .option("validators", {
+              description: "list of validators in the *existing* InnerSet",
+              default: [],
+              type: "array",
+              string: true
+            });
+        },
+        handler: handleInner
+      })
+      .parse(process.argv.slice(4)); // slice out truffle nonsense
+  } catch (e) {
+    cb(e);
+    return;
+  }
+  cb();
+};

--- a/contracts/validator/scripts/genesis/generate.js
+++ b/contracts/validator/scripts/genesis/generate.js
@@ -5,6 +5,10 @@ const template = require("./genesisTemplate.json");
 const OuterSet = artifacts.require("OuterSet");
 const InnerSetInitial = artifacts.require("InnerSetInitial");
 
+const clearTruffle = () => {
+  process.stdout.write("\r\x1b[A\x1b[A\x1b[2K");
+};
+
 module.exports = async function generateGenesis(cb) {
   try {
     const { argv } = yargs
@@ -62,7 +66,15 @@ module.exports = async function generateGenesis(cb) {
       .option("stderr", {
         describe: "print to stderr instead of stdout",
         default: false
+      })
+      .option("quiet", {
+        describe: "clear Truffle output noise",
+        default: false
       });
+
+    if (argv.quiet) {
+      clearTruffle();
+    }
 
     const output = argv.stderr ? console.error : console.log; // eslint-disable-line
 


### PR DESCRIPTION
To run:
```
yarn --silent run cli --help --quiet

yarn cli validator list
yarn cli inner deploy --validators 0xf00... 0xba3... 0xba2...
```

Uses Truffle under the hood (= uses Truffle config for `--network`)

Also added `--quiet` flag to `generate:genesis` script.